### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,10 +11,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-  permissions:
-    contents: read
-    pull-requests: write
-  
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
     - uses: actions/checkout@v4
     - name: set up JDK 1.8


### PR DESCRIPTION
Potential fix for [https://github.com/nekkron/dependabot-demo/security/code-scanning/6](https://github.com/nekkron/dependabot-demo/security/code-scanning/6)

To fix the issue, the `permissions` block should be moved under the `build` job to ensure it is explicitly scoped to that job. This will make the permissions clear and avoid any ambiguity. The updated workflow will explicitly define the permissions for the `build` job, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
