### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/nekkron/dependabot-demo/security/code-scanning/7](https://github.com/nekkron/dependabot-demo/security/code-scanning/7)

To fix the problem, add an explicit `permissions` block at the root of the `.github/workflows/android.yml` workflow file, above the jobs definition. This root-level block should minimally specify `contents: read`. This ensures that any jobs in the workflow, unless they include their own override, will inherit restricted permissions rather than possibly inheriting broadened organization or repository defaults. This fix does not change any existing functionality, as the build job already sets more permissive (but still minimal) permissions for its needs.

Edit `.github/workflows/android.yml` by adding:
```yaml
permissions:
  contents: read
```
above the `jobs:` key (after `on:` block).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
